### PR TITLE
Various minor functionality changes:

### DIFF
--- a/.spr.yml
+++ b/.spr.yml
@@ -1,8 +1,11 @@
-githubRepoOwner: ejoffe
+githubRepoOwner: mattskl-openai
 githubRepoName: spr
 githubHost: github.com
+githubRemote: origin
+githubBranch: main
 requireChecks: true
 requireApproval: false
-mergeMethod: rebase
+mergeMethod: squash
 mergeQueue: false
 forceFetchTags: false
+prPrefix: mattskl

--- a/cmd/reword/main.go
+++ b/cmd/reword/main.go
@@ -97,6 +97,7 @@ func appendCommitID(filename string, missingNewLine bool) {
 	if missingNewLine {
 		appendfile.WriteString("\n")
 	}
+
 	appendfile.WriteString("\n")
 	appendfile.WriteString(fmt.Sprintf("commit-id:%s\n", commitID.String()[:8]))
 }

--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,7 @@ type RepoConfig struct {
 
 	ShowPrTitlesInStack    bool `default:"false" yaml:"showPrTitlesInStack"`
 	BranchPushIndividually bool `default:"false" yaml:"branchPushIndividually"`
+	PrPrefix         string `default:"spr" yaml:"prPrefix"`
 }
 
 type UserConfig struct {
@@ -47,6 +48,7 @@ type UserConfig struct {
 	LogGitHubCalls   bool `default:"true" yaml:"logGitHubCalls"`
 	StatusBitsHeader bool `default:"true" yaml:"statusBitsHeader"`
 	StatusBitsEmojis bool `default:"true" yaml:"statusBitsEmojis"`
+	ChainUpdateDepth int  `default:"1" yaml:"chainUpdateDepth"`
 
 	CreateDraftPRs       bool `default:"false" yaml:"createDraftPRs"`
 	PreserveTitleAndBody bool `default:"false" yaml:"preserveTitleAndBody"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -37,6 +37,7 @@ func TestDefaultConfig(t *testing.T) {
 		},
 		User: &UserConfig{
 			ShowPRLink:       true,
+			ChainUpdateDepth: 1,
 			LogGitCommands:   false,
 			LogGitHubCalls:   false,
 			StatusBitsHeader: true,

--- a/github/githubclient/client.go
+++ b/github/githubclient/client.go
@@ -203,7 +203,7 @@ func (c *client) GetInfo(ctx context.Context, gitcmd git.GitInterface) *github.G
 	targetBranch := c.config.Repo.GitHubBranch
 	localCommitStack := git.GetLocalCommitStack(c.config, gitcmd)
 
-	pullRequests := matchPullRequestStack(c.config.Repo, targetBranch, localCommitStack, pullRequestConnection)
+	pullRequests := matchPullRequestStack(c.config, targetBranch, localCommitStack, pullRequestConnection)
 	for _, pr := range pullRequests {
 		if pr.Ready(c.config) {
 			pr.MergeStatus.Stacked = true
@@ -224,7 +224,7 @@ func (c *client) GetInfo(ctx context.Context, gitcmd git.GitInterface) *github.G
 }
 
 func matchPullRequestStack(
-	repoConfig *config.RepoConfig,
+	cfg *config.Config,
 	targetBranch string,
 	localCommitStack []git.Commit,
 	allPullRequests fezzik_types.PullRequestConnection) []*github.PullRequest {
@@ -261,11 +261,11 @@ func matchPullRequestStack(
 			InQueue:    node.MergeQueueEntry != nil,
 		}
 
-		matches := git.BranchNameRegex.FindStringSubmatch(node.HeadRefName)
-		if matches != nil {
+		commitID := git.GetCommitIdFromBranchName(cfg, node.HeadRefName)
+		if commitID != "" {
 			commit := (*node.Commits.Nodes)[len(*node.Commits.Nodes)-1].Commit
 			pullRequest.Commit = git.Commit{
-				CommitID:   matches[2],
+				CommitID:   commitID,
 				CommitHash: commit.Oid,
 				Subject:    commit.MessageHeadline,
 				Body:       commit.MessageBody,
@@ -322,11 +322,10 @@ func matchPullRequestStack(
 			break
 		}
 
-		matches := git.BranchNameRegex.FindStringSubmatch(currpr.ToBranch)
-		if matches == nil {
+		nextCommitID := git.GetCommitIdFromBranchName(cfg, currpr.ToBranch)
+		if nextCommitID == "" {
 			panic(fmt.Errorf("invalid base branch for pull request:%s", currpr.ToBranch))
 		}
-		nextCommitID := matches[2]
 
 		currpr = pullRequestMap[nextCommitID]
 	}
@@ -431,11 +430,11 @@ func formatStackMarkdown(commit git.Commit, stack []*github.PullRequest, showPrT
 	var buf bytes.Buffer
 	for i := len(stack) - 1; i >= 0; i-- {
 		isCurrent := stack[i].Commit == commit
-		var suffix string
+		var prefix string
 		if isCurrent {
-			suffix = " ⬅"
+			prefix = "➡ "
 		} else {
-			suffix = ""
+			prefix = "  "
 		}
 		var prTitle string
 		if showPrTitlesInStack {
@@ -444,7 +443,7 @@ func formatStackMarkdown(commit git.Commit, stack []*github.PullRequest, showPrT
 			prTitle = ""
 		}
 
-		buf.WriteString(fmt.Sprintf("- %s#%d%s\n", prTitle, stack[i].Number, suffix))
+		buf.WriteString(fmt.Sprintf("- %s%s#%d\n", prefix, prTitle, stack[i].Number))
 	}
 
 	return buf.String()

--- a/github/githubclient/client_test.go
+++ b/github/githubclient/client_test.go
@@ -522,9 +522,10 @@ func TestMatchPullRequestStack(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		repoConfig := &config.RepoConfig{}
+		config := config.DefaultConfig()
+		config.Repo.PrPrefix = "spr/master"
 		t.Run(tc.name, func(t *testing.T) {
-			actual := matchPullRequestStack(repoConfig, "master", tc.commits, tc.prs)
+			actual := matchPullRequestStack(config, "master", tc.commits, tc.prs)
 			require.Equal(t, tc.expect, actual)
 		})
 	}
@@ -566,8 +567,8 @@ It even includes some **markdown** formatting.
 ---
 
 **Stack**:
-- #2 ⬅
-- #1
+- ➡ #2
+-   #1
 
 
 ⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*`,
@@ -623,8 +624,8 @@ It even includes some **markdown** formatting.
 ---
 
 **Stack**:
-- Title B #2 ⬅
-- Title A #1
+- ➡ Title B #2
+-   Title A #1
 
 
 ⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*`,

--- a/spr/spr_test.go
+++ b/spr/spr_test.go
@@ -25,6 +25,7 @@ func makeTestObjects(t *testing.T) (
 	cfg.Repo.GitHubRemote = "origin"
 	cfg.Repo.GitHubBranch = "master"
 	cfg.Repo.MergeMethod = "rebase"
+	cfg.Repo.PrPrefix = "spr/master"
 	gitmock = mockgit.NewMockGit(t)
 	githubmock = mockclient.NewMockClient(t)
 	githubmock.Info = &github.GitHubInfo{


### PR DESCRIPTION
- Update spr to allow specifying PR branch prefix.
- Allow commit-id to be non-8-char. Now it can be any word 3-40 chars
- Put stack pointer on left side of PR comment
- Temp update of spr reword

pr:prefixChanges

---

**Stack**:
-   #9
-   #8
- ➡ #7


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*