### PR TITLE
Error on finding remote PRs without matching local commit.

### DIFF
--- a/spr/spr_test.go
+++ b/spr/spr_test.go
@@ -42,6 +42,7 @@ func makeTestObjects(t *testing.T) (
 }
 
 func TestSPRBasicFlowFourCommitsQueue(t *testing.T) {
+	fmt.Println("TestSPRBasicFlowFourCommitsQueue")
 	s, gitmock, githubmock, _, output := makeTestObjects(t)
 	assert := require.New(t)
 	ctx := context.Background()
@@ -201,6 +202,7 @@ func TestSPRBasicFlowFourCommitsQueue(t *testing.T) {
 }
 
 func TestSPRBasicFlowFourCommits(t *testing.T) {
+	fmt.Println("TestSPRBasicFlowFourCommits")
 	s, gitmock, githubmock, _, output := makeTestObjects(t)
 	assert := require.New(t)
 	ctx := context.Background()
@@ -322,6 +324,7 @@ func TestSPRBasicFlowFourCommits(t *testing.T) {
 }
 
 func TestSPRMergeCount(t *testing.T) {
+	fmt.Println("TestSPRMergeCount")
 	s, gitmock, githubmock, _, output := makeTestObjects(t)
 	assert := require.New(t)
 	ctx := context.Background()
@@ -393,6 +396,7 @@ func TestSPRMergeCount(t *testing.T) {
 }
 
 func TestSPRAmendCommit(t *testing.T) {
+	fmt.Println("TestSPRAmendCommit")
 	s, gitmock, githubmock, _, output := makeTestObjects(t)
 	assert := require.New(t)
 	ctx := context.Background()
@@ -483,6 +487,7 @@ func TestSPRAmendCommit(t *testing.T) {
 }
 
 func TestSPRReorderCommit(t *testing.T) {
+	fmt.Println("TestSPRReorderCommit")
 	s, gitmock, githubmock, _, output := makeTestObjects(t)
 	assert := require.New(t)
 	ctx := context.Background()
@@ -606,7 +611,12 @@ func TestSPRReorderCommit(t *testing.T) {
 	// TODO : add a call to merge and check merge order
 }
 
+// TODO(mattskl): consider usefulness of SPR deleting commits for me.
+// So far, it's only been unwanted and unintuitive.
 func TestSPRDeleteCommit(t *testing.T) {
+	fmt.Println("TestSPRDeleteCommit -- skipped")
+	return
+
 	s, gitmock, githubmock, _, output := makeTestObjects(t)
 	assert := require.New(t)
 	ctx := context.Background()
@@ -691,6 +701,7 @@ func TestSPRDeleteCommit(t *testing.T) {
 }
 
 func TestAmendNoCommits(t *testing.T) {
+	fmt.Println("TestAmendNoCommits")
 	s, gitmock, _, _, output := makeTestObjects(t)
 	assert := require.New(t)
 	ctx := context.Background()
@@ -701,6 +712,7 @@ func TestAmendNoCommits(t *testing.T) {
 }
 
 func TestAmendOneCommit(t *testing.T) {
+	fmt.Println("TestAmendOneCommit")
 	s, gitmock, _, input, output := makeTestObjects(t)
 	assert := require.New(t)
 	ctx := context.Background()
@@ -718,6 +730,7 @@ func TestAmendOneCommit(t *testing.T) {
 }
 
 func TestAmendTwoCommits(t *testing.T) {
+	fmt.Println("TestAmendTwoCommits")
 	s, gitmock, _, input, output := makeTestObjects(t)
 	assert := require.New(t)
 	ctx := context.Background()
@@ -740,6 +753,7 @@ func TestAmendTwoCommits(t *testing.T) {
 }
 
 func TestAmendInvalidInput(t *testing.T) {
+	fmt.Println("TestAmendInvalidInput")
 	s, gitmock, _, input, output := makeTestObjects(t)
 	assert := require.New(t)
 	ctx := context.Background()


### PR DESCRIPTION
This 'feature' has never done what I'd expect, and it was silent too..

pr:noDelete

---

**Stack**:
-   #20
-   #19
- ➡ #18


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*