### PR TITLE
Remove alignment during UpdatePR; add test with merge 1 + update.

### DIFF
--- a/spr/spr.go
+++ b/spr/spr.go
@@ -139,7 +139,7 @@ func (sd *stackediff) UpdatePullRequests(ctx context.Context, reviewers []string
 		return
 	}
 	sd.profiletimer.Step("UpdatePullRequests::FetchAndGetGitHubInfo")
-	localCommits := alignLocalCommits(git.GetLocalCommitStack(sd.config, sd.gitcmd), githubInfo.PullRequests)
+	localCommits := git.GetLocalCommitStack(sd.config, sd.gitcmd)
 	sd.profiletimer.Step("UpdatePullRequests::GetLocalCommitStack")
 
 	// detect PRs without matching local commits;


### PR DESCRIPTION
UpdatePR has several calls to 'match' local commits vs PRs.
`alignLocalCommits` drops local commits that don't exist as PRs.
This is undesirable since it seems to greatly mess up creation of PRs
for new commits that didn't previously have an associated PR.

This likely messes up merge queue support, which introduced this logic - https://github.com/ejoffe/spr/pull/347
Perhaps what's needed is to get local commits again without alignment
after handling merge queue logic?

pr:noAlign